### PR TITLE
Fix PDF download link by forcing attachment disposition

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, url_for
+from flask import Flask, render_template, url_for, send_from_directory
 
 app = Flask(__name__)
 
@@ -7,6 +7,10 @@ def home():
     # Render the single combined HTML page for the homepage
     # Ensure 'index_combined.html' is in your 'templates' folder
     return render_template('index_combined.html')
+
+@app.route('/download-pdf')
+def download_pdf():
+    return send_from_directory('static', 'ai-coding-guide.pdf', as_attachment=True)
 
 # The /ai and /tech routes are no longer needed as content is consolidated
 # into index_combined.html and accessed via internal links.

--- a/templates/ai.html
+++ b/templates/ai.html
@@ -124,7 +124,7 @@
                 Ready to dive deeper into AI? Download our comprehensive guide:
             </p>
             <div class="text-center mt-8">
-                <a class="ai-button" href="{{ url_for('static', filename='ai-coding-guide.pdf') }}" download>
+                <a class="ai-button" href="{{ url_for('download_pdf') }}" download>
                     Download Our AI Guide (PDF)
                 </a>
             </div>

--- a/templates/index_combined.html
+++ b/templates/index_combined.html
@@ -800,7 +800,7 @@
                     <p class="text-xl font-semibold text-gray-700 mb-8 animate-fadeInUp">
                         📚 Ready to dive deeper into AI? Download our comprehensive guide:
                     </p>
-                    <a href="{{ url_for('static', filename='ai-coding-guide.pdf') }}" download class="btn-primary text-white font-bold py-4 px-8 rounded-full text-lg flex items-center mx-auto glow-effect animate-fadeInUp delay-100">
+                    <a href="{{ url_for('download_pdf') }}" download class="btn-primary text-white font-bold py-4 px-8 rounded-full text-lg flex items-center mx-auto glow-effect animate-fadeInUp delay-100">
                         <span class="mr-2">📥</span>
                         Download Our AI Guide (PDF)
                     </a>


### PR DESCRIPTION
The PDF file was not downloading correctly because the browser was likely opening it inline. This change introduces a new Flask route `/download-pdf` that serves the file with the `Content-Disposition` header set to `attachment`, which forces the browser to download the file rather than displaying it.

The links in `index_combined.html` and `ai.html` have been updated to point to this new route.